### PR TITLE
Minor changes to PR 2259

### DIFF
--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -370,6 +370,4 @@ inline int h2o_http3_has_received_settings(h2o_http3_conn_t *conn)
     return conn->qpack.enc != NULL;
 }
 
-void h2o_http3_track_sendmsg_init(h2o_loop_t *loop);
-
 #endif

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -71,9 +71,9 @@ static void on_track_sendmsg_timer(h2o_timer_t *timeout)
         track_sendmsg.successes = 0;
         return;
     }
-    fprintf(stderr, "sendmsg failed %zu time%s, succeeded: %zu time%s, over the last minute: %s\n", track_sendmsg.failures,
-            track_sendmsg.failures > 1 ? "s" : "", track_sendmsg.successes, track_sendmsg.successes > 1 ? "s" : "",
-            strerror(track_sendmsg.last_errno));
+    fprintf(stderr, "sendmsg failed %" PRIu64 " time%s, succeeded: %" PRIu64 " time%s, over the last minute: %s\n",
+            track_sendmsg.failures, track_sendmsg.failures > 1 ? "s" : "", track_sendmsg.successes,
+            track_sendmsg.successes > 1 ? "s" : "", strerror(track_sendmsg.last_errno));
     track_sendmsg.failures = 0;
     track_sendmsg.successes = 0;
     track_sendmsg.last_errno = 0;

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -165,7 +165,7 @@ int h2o_http3_send_datagram(h2o_http3_ctx_t *ctx, quicly_datagram_t *p)
     while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
         ;
 
-    if (ret != -1) {
+    if (ret == -1) {
         /* The UDP stack returns EINVAL (linux) or EADDRNOTAVAIL (darwin, and presumably other BSD) when it was unable to use the
          * designated source address.  We communicate that back to the caller so that the connection can be closed immediately. */
         if (p->src.sa.sa_family != AF_UNSPEC && (errno == EINVAL || errno == EADDRNOTAVAIL))

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -71,9 +71,10 @@ static void on_track_sendmsg_timer(h2o_timer_t *timeout)
         track_sendmsg.successes = 0;
         return;
     }
+    char errstr[256];
     fprintf(stderr, "sendmsg failed %" PRIu64 " time%s, succeeded: %" PRIu64 " time%s, over the last minute: %s\n",
             track_sendmsg.failures, track_sendmsg.failures > 1 ? "s" : "", track_sendmsg.successes,
-            track_sendmsg.successes > 1 ? "s" : "", strerror(track_sendmsg.last_errno));
+            track_sendmsg.successes > 1 ? "s" : "", h2o_strerror_r(track_sendmsg.last_errno, errstr, sizeof(errstr)));
     track_sendmsg.failures = 0;
     track_sendmsg.successes = 0;
     track_sendmsg.last_errno = 0;

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -81,14 +81,19 @@ void on_track_sendmsg_timer(h2o_timer_t *timeout)
     char errstr[256];
 
     pthread_mutex_lock(&track_sendmsg.locked.mutex);
+
     uint64_t total_successes = __sync_fetch_and_add(&track_sendmsg.total_successes, 0),
              cur_successes = total_successes - track_sendmsg.locked.prev_successes;
+
     fprintf(stderr, "sendmsg failed %" PRIu64 " time%s, succeeded: %" PRIu64 " time%s, over the last minute: %s\n",
             track_sendmsg.locked.cur_failures, track_sendmsg.locked.cur_failures > 1 ? "s" : "", cur_successes,
             cur_successes > 1 ? "s" : "", h2o_strerror_r(track_sendmsg.locked.last_errno, errstr, sizeof(errstr)));
+
     track_sendmsg.locked.prev_successes = total_successes;
     track_sendmsg.locked.cur_failures = 0;
     track_sendmsg.locked.last_errno = 0;
+
+    pthread_mutex_unlock(&track_sendmsg.locked.mutex);
 }
 
 /**

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -57,47 +57,38 @@ struct st_h2o_http3_ingress_unistream_t {
 
 const ptls_iovec_t h2o_http3_alpn[1] = {{(void *)H2O_STRLIT("h3-25")}};
 
+static void on_track_sendmsg_timer(h2o_timer_t *timeout);
+
 static struct {
-    uint64_t failures;
-    uint64_t successes;
-    int last_errno;
-    h2o_timer_t timer;
-    h2o_loop_t *loop;
-} track_sendmsg;
+    /**
+     * counts number of successful invocations of `sendmsg` since the process was launched
+     */
+    uint64_t total_successes;
+    /**
+     * struct that retains information since previous log emission. Needs locked access using `locked.mutex`.
+     */
+    struct {
+        pthread_mutex_t mutex;
+        uint64_t prev_successes;
+        uint64_t cur_failures;
+        int last_errno;
+        h2o_timer_t timer;
+    } locked;
+} track_sendmsg = {.locked = {PTHREAD_MUTEX_INITIALIZER, .timer = {.cb = on_track_sendmsg_timer}}};
 
-static void on_track_sendmsg_timer(h2o_timer_t *timeout)
+void on_track_sendmsg_timer(h2o_timer_t *timeout)
 {
-    if (track_sendmsg.failures == 0) {
-        track_sendmsg.successes = 0;
-        return;
-    }
     char errstr[256];
+
+    pthread_mutex_lock(&track_sendmsg.locked.mutex);
+    uint64_t total_successes = __sync_fetch_and_add(&track_sendmsg.total_successes, 0),
+             cur_successes = total_successes - track_sendmsg.locked.prev_successes;
     fprintf(stderr, "sendmsg failed %" PRIu64 " time%s, succeeded: %" PRIu64 " time%s, over the last minute: %s\n",
-            track_sendmsg.failures, track_sendmsg.failures > 1 ? "s" : "", track_sendmsg.successes,
-            track_sendmsg.successes > 1 ? "s" : "", h2o_strerror_r(track_sendmsg.last_errno, errstr, sizeof(errstr)));
-    track_sendmsg.failures = 0;
-    track_sendmsg.successes = 0;
-    track_sendmsg.last_errno = 0;
-    h2o_timer_link(track_sendmsg.loop, 60000, &track_sendmsg.timer);
-}
-
-void h2o_http3_track_sendmsg_init(h2o_loop_t *loop)
-{
-    assert(track_sendmsg.loop == NULL);
-    track_sendmsg.loop = loop;
-    h2o_timer_init(&track_sendmsg.timer, on_track_sendmsg_timer);
-    h2o_timer_link(loop, 60000, &track_sendmsg.timer);
-}
-
-static void track_sendmsg_failure(void)
-{
-    __sync_fetch_and_add(&track_sendmsg.failures, 1);
-    track_sendmsg.last_errno = errno;
-}
-
-static void track_sendmsg_success(void)
-{
-    __sync_fetch_and_add(&track_sendmsg.successes, 1);
+            track_sendmsg.locked.cur_failures, track_sendmsg.locked.cur_failures > 1 ? "s" : "", cur_successes,
+            cur_successes > 1 ? "s" : "", h2o_strerror_r(track_sendmsg.locked.last_errno, errstr, sizeof(errstr)));
+    track_sendmsg.locked.prev_successes = total_successes;
+    track_sendmsg.locked.cur_failures = 0;
+    track_sendmsg.locked.last_errno = 0;
 }
 
 /**
@@ -169,7 +160,7 @@ int h2o_http3_send_datagram(h2o_http3_ctx_t *ctx, quicly_datagram_t *p)
     while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
         ;
 
-    if (ret == -1) {
+    if (ret != -1) {
         /* The UDP stack returns EINVAL (linux) or EADDRNOTAVAIL (darwin, and presumably other BSD) when it was unable to use the
          * designated source address.  We communicate that back to the caller so that the connection can be closed immediately. */
         if (p->src.sa.sa_family != AF_UNSPEC && (errno == EINVAL || errno == EADDRNOTAVAIL))
@@ -177,9 +168,16 @@ int h2o_http3_send_datagram(h2o_http3_ctx_t *ctx, quicly_datagram_t *p)
 
         /* Temporary failure to send a packet is not a permanent error fo the connection. (TODO do we want do something more
          * specific?) */
-        track_sendmsg_failure();
+
+        /* Log the number of failed invocations once per minute, if there has been such a failure. */
+        pthread_mutex_lock(&track_sendmsg.locked.mutex);
+        ++track_sendmsg.locked.cur_failures;
+        track_sendmsg.locked.last_errno = errno;
+        if (!h2o_timer_is_linked(&track_sendmsg.locked.timer))
+            h2o_timer_link(ctx->loop, 60000, &track_sendmsg.locked.timer);
+        pthread_mutex_unlock(&track_sendmsg.locked.mutex);
     } else {
-        track_sendmsg_success();
+        __sync_fetch_and_add(&track_sendmsg.total_successes, 1);
     }
 
     return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -2244,8 +2244,6 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
         listeners[i].sock->data = listeners + i;
         /* setup quic context and the unix socket to receive forwarded packets */
         if (thread_index < conf.quic.num_threads && listener_config->quic.ctx != NULL) {
-            if (thread_index == 0)
-                h2o_http3_track_sendmsg_init(conf.threads[0].ctx.loop);
             h2o_http3_init_context(&listeners[i].http3.ctx.super, conf.threads[thread_index].ctx.loop, listeners[i].sock,
                                    listener_config->quic.ctx, on_http3_accept, NULL);
             h2o_http3_set_context_identifier(&listeners[i].http3.ctx.super, (uint32_t)conf.quic.num_threads, (uint32_t)thread_index,


### PR DESCRIPTION
This PR does the following:
* reverts the addition of a new API
* activates the timeout only when a failure is observed
* for safety, consistently uses sync accessors or mutex